### PR TITLE
Update share build setup

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for Alien::gdal
 
 1.38 2024-xx-xx
     - Share builds:
+        Use the internal libgeotiff
         Disable Java bindings for faster builds
         Disable use of system libspatialite if Alien::proj is a share build.
           This sidesteps seg faults due to use of two libproj instances.

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Alien::gdal
 
+1.38 2024-xx-xx
+    - Share builds: Disable Java bindings for faster builds
+
 1.37 2024-05-28
     - More effective search for the data dir for systems installs using homebrew
 

--- a/Changes
+++ b/Changes
@@ -1,10 +1,14 @@
 Revision history for Alien::gdal
 
 1.38 2024-xx-xx
-    - Share builds: Disable Java bindings for faster builds
+    - Share builds:
+        Disable Java bindings for faster builds
+        Disable use of system libspatialite if Alien::proj is a share build.
+          This sidesteps seg faults due to use of two libproj instances.
+    - Tweaks to the build system.
 
 1.37 2024-05-28
-    - More effective search for the data dir for systems installs using homebrew
+    - More effective search for the data dir for system installs using homebrew
 
 1.36 2022-11-28
     - Unices: fix rpath check for lib, lib64 and lib32

--- a/alienfile
+++ b/alienfile
@@ -333,11 +333,11 @@ share {
     #  hack
     if ($^O =~ /darwin/) {
       push @DYLD_LIBRARY_PATH, @ld_lib_path;
-      Alien::Build->log('DYLD_LIBRARY_PATH: ' . join ':', @DYLD_LIBRARY_PATH);
+      Alien::Build->log('DYLD_LIBRARY_PATH: ' . join ':', grep {defined} @DYLD_LIBRARY_PATH);
     }
     else {
       push @LD_LIBRARY_PATH, @ld_lib_path;
-      Alien::Build->log('LD_LIBRARY_PATH: ' . join ':', @LD_LIBRARY_PATH);
+      Alien::Build->log('LD_LIBRARY_PATH: ' . join ':', grep {defined} @LD_LIBRARY_PATH);
     }
 
     #foreach my $env_var (qw /LD_LIBRARY_PATH DYLD_LIBRARY_PATH LDFLAGS CFLAGS CXXFLAGS/) {

--- a/alienfile
+++ b/alienfile
@@ -6,6 +6,7 @@ use Env qw /@PATH @LD_LIBRARY_PATH @DYLD_LIBRARY_PATH @PROJ_LIB/;
 use Path::Tiny qw /path/;
 use List::Util;
 use FFI::CheckLib;
+use Config;
 
 my $on_windows = $^O =~ /mswin/i;
 my $on_automated_rig
@@ -218,8 +219,10 @@ share {
     Alien::Build->log('LD_LIBRARY_PATH: ' . join ':', map {defined $_ ? $_ : ''} @LD_LIBRARY_PATH);
     my @ld_flags;
     my @ld_lib_path;
+    my @cmake_prefix_path;
     #  system installs won't necessarily have dist dirs
     if (Alien::proj->install_type eq 'share') {
+      push @cmake_prefix_path, path('Alien::proj'->dist_dir);
       push @with_args, '-DPROJ_INCLUDE_DIR=' . path (Alien::proj->dist_dir . '/include')->stringify;
       my $libfile = find_lib_file (
         lib   => 'proj',
@@ -247,6 +250,7 @@ share {
       }
     }
     if (Alien::libtiff->install_type eq 'share') {
+      push @cmake_prefix_path, path('Alien::libtiff'->dist_dir);
       my $libtiff_include = path ('Alien::libtiff'->dist_dir . '/include')->stringify;
       my $libfile = find_lib_file (
         lib   => 'tiff',
@@ -261,26 +265,29 @@ share {
       }
     }
     if ($have_spatialite && Alien::spatialite->install_type eq 'share') {
+      push @cmake_prefix_path, path('Alien::spatialite'->dist_dir);
       #  need to check for this under cmake?
     }
     if (Alien::sqlite->install_type eq 'share') {
+      push @cmake_prefix_path, path('Alien::sqlite'->dist_dir);
       my $sqlite_include = path ('Alien::sqlite'->dist_dir . '/include')->stringify;
       my $libfile = find_lib_file (
           lib   => 'sqlite3',
           alien => 'Alien::sqlite',
       );
-      my $exe_extension = ($on_windows ? '.exe' : '');
-      my $sqlite_exe = path ('Alien::sqlite'->dist_dir . "/bin/sqlite3$exe_extension");
+      # my $exe_extension = ($on_windows ? '.exe' : '');
+      # my $sqlite_exe = path ('Alien::sqlite'->dist_dir . "/bin/sqlite3$exe_extension");
       push @with_args, (
-        "-DEXE_SQLITE3=$sqlite_exe",
-        "-DSQLITE3_LIBRARY=$libfile",
-        "-DSQLITE3_INCLUDE_DIR=$sqlite_include",
+        # "-DEXE_SQLITE3=$sqlite_exe",
+        "-DSQLite3_LIBRARY=$libfile",
+        "-DSQLite3_INCLUDE_DIR=$sqlite_include",
       );
       if (!$on_windows) {
         push @ld_lib_path, (Alien::sqlite->dist_dir . '/lib');
       }
     }
     if (Alien::geos::af->install_type eq 'share') {
+      push @cmake_prefix_path, path('Alien::geos::af'->dist_dir);
       my $libfile = find_lib_file (
           lib   => 'geos',
           alien => 'Alien::geos::af',
@@ -328,6 +335,17 @@ share {
     #foreach my $env_var (qw /LD_LIBRARY_PATH DYLD_LIBRARY_PATH LDFLAGS CFLAGS CXXFLAGS/) {
     #  say "ENV: $env_var is " . ($ENV{$env_var} // '');
     #}
+    if (@cmake_prefix_path) {
+      my $path = join $Config{path_sep}, @cmake_prefix_path;
+      meta->around_hook(
+        build => sub {
+          my ($orig, $build, @args) = @_;
+          $build->log("Setting CMAKE_PREFIX_PATH to $path");
+          local $ENV{CMAKE_PREFIX_PATH} = $path;
+          $orig->($build, @args);
+        }
+      );
+    }
     
     my $cmake_cmd = [
       '%{cmake}',

--- a/alienfile
+++ b/alienfile
@@ -203,6 +203,7 @@ share {
     my @with_args = (
       #https://gdal.org/build_hints.html#cmdoption-arg-GDAL_USE_-Packagename_in_upper_case-BOOL
       @automated_rig_config_args,
+      '-DGDAL_USE_GEOTIFF_INTERNAL:BOOL=ON',  #  until we have an alien
       '-DGDAL_USE_MSSQL_ODBC=OFF',
       '-DGDAL_USE_MSSQL_NCLI=OFF',
       '-DGDAL_USE_MYSQL=OFF',

--- a/alienfile
+++ b/alienfile
@@ -269,6 +269,13 @@ share {
       push @cmake_prefix_path, path('Alien::spatialite'->dist_dir);
       #  need to check for this under cmake?
     }
+    elsif (Alien::proj->install_type eq 'share') {
+      #  spatialite depends on proj and this can cause grief if proj is a share install
+      #  and spatialite is found by CMake
+      #  https://gdal.org/en/latest/development/building_from_source.html#conflicting-proj-libraries
+      push @with_args, '-DGDAL_USE_SPATIALITE=OFF';
+    }
+
     if (Alien::sqlite->install_type eq 'share') {
       push @cmake_prefix_path, path('Alien::sqlite'->dist_dir);
       my $sqlite_include = path ('Alien::sqlite'->dist_dir . '/include')->stringify;

--- a/lib/Alien/gdal.pm
+++ b/lib/Alien/gdal.pm
@@ -11,7 +11,7 @@ use Path::Tiny qw /path/;
 use List::Util qw /uniq/;
 use Alien::proj;
 
-our $VERSION = '1.37';
+our $VERSION = '1.38';
 
 my ($have_geos, $have_proj, $have_spatialite);
 my @have_aliens;

--- a/t/00-load.t
+++ b/t/00-load.t
@@ -26,6 +26,31 @@ foreach my $alien (qw /Alien::sqlite Alien::libtiff Alien::proj Alien::geos::af/
     $alien_versions{$alien} = $alien->version;
 }
 
+my $have_ldd = !!`ldd --help`;
+if (Alien::gdal->install_type eq 'share' && $have_ldd) {
+    my $dylib = Alien::gdal->dist_dir . '/lib/libgdal.so';
+    if (-e $dylib) {
+        my @deps = `ldd $dylib`;
+        my %collated;
+
+        foreach my $line (@deps) {
+            #  https://gdal.org/en/latest/development/building_from_source.html#conflicting-proj-libraries
+            #  blunt approach but proj is the main culprit and there seem to be some legit double ups.
+            next if not $line =~ 'libproj';
+
+            $line =~ s/[\r\n]+//g;
+            # diag $line;
+            $line =~ s/^\s+//;
+            my ($lib, $path) = split /\s+=>\s+/, $line, 2;
+            # diag "$lib --- $path";
+            $lib =~ s/\.so.+//;
+
+            is $collated{$lib}, undef, "No duplicate dylib dep for $lib, also have $path.  Expect segfaults.";
+
+            $collated{$lib} = $path;
+        }
+    }
+}
 
 done_testing();
 


### PR DESCRIPTION
Share builds:
  * Use the internal libgeotiff
  * Disable Java bindings for faster builds
  * Disable use of system libspatialite if Alien::proj is a share build.  This sidesteps seg faults due to use of two libproj instances.
